### PR TITLE
Add matrix-rtc support

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -51,8 +51,12 @@ jobs:
       - name: Add secrets to docker-compose.yml
         env:
           MATRIX_POSTGRES_PASSWORD: ${{ secrets.matrix_postgres_password }}
+          LIVEKIT_API_KEY: ${{ secrets.livekit_api_key }}
+          LIVEKIT_API_SECRET: ${{ secrets.livekit_api_secret }}
         run: |
           sed -i "s|(matrix_postgres_password)|$MATRIX_POSTGRES_PASSWORD|g" $GITHUB_WORKSPACE/matrix/docker-compose.yml
+          sed -i "s|(livekit_api_key)|$LIVEKIT_API_KEY|g" $GITHUB_WORKSPACE/matrix/docker-compose.yml
+          sed -i "s|(livekit_api_secret)|$LIVEKIT_API_SECRET|g" $GITHUB_WORKSPACE/matrix/docker-compose.yml
 
 
       - name: Create Secrets

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -18,12 +18,53 @@ pa.fariszr.com {
 matrix.fariszr.com {
 	reverse_proxy synapse:8008
 	encode zstd gzip
-	# add sliding sync availability (https://github.com/matrix-org/sliding-sync)
-	respond /.well-known/matrix/client ` {
-		"m.homeserver": {
-			"base_url":"https://matrix.fariszr.com"
+	# Updated .well-known to point livekit_service_url to the JWT endpoint on the new domain
+	respond /.well-known/matrix/client 200 {
+		body `{
+			"m.homeserver": {
+				"base_url": "https://matrix.fariszr.com"
+			},
+			"org.matrix.msc4143.rtc_foci": [
+				{
+					"type": "livekit",
+					"livekit_service_url": "https://matrixrtc.fariszr.com/livekit/jwt"
+				}
+			]
+		}`
+		headers {
+			Content-Type application/json
+			Access-Control-Allow-Origin *
+			# Add other CORS headers if needed based on client requirements
+            # Access-Control-Allow-Methods GET, POST, OPTIONS
+            # Access-Control-Allow-Headers Authorization, Content-Type
 		}
-	}	`
+	}
+}
+
+# Updated LiveKit reverse proxy to use the new domain
+matrixrtc.fariszr.com {
+	encode zstd gzip
+
+	# Route JWT requests to the lk-jwt-service container on its internal port 8080
+	handle /livekit/jwt* {
+		reverse_proxy lk-jwt-service:8080
+	}
+
+	# Route SFU WebSocket requests to the livekit container on its internal port 7880
+	handle /livekit/sfu* {
+		reverse_proxy livekit:7880 {
+			# Required for WebSocket proxying
+			header_up Host {http.reverse_proxy.upstream.hostport}
+			header_up X-Forwarded-Host {host}
+            header_up Upgrade {header.Upgrade}
+            header_up Connection {header.Connection}
+		}
+	}
+
+    # Optional: Add a default handler if needed, e.g., redirect or show a message
+    # handle {
+    #    respond "LiveKit backend" 200
+    # }
 }
 
 import /etc/caddy/configs/*.caddyfile

--- a/matrix/docker-compose.yml
+++ b/matrix/docker-compose.yml
@@ -73,7 +73,7 @@ services:
 
   # Added JWT Authentication Service for Element Call
   lk-jwt-service:
-    image: ghcr.io/element-hq/lk-jwt-service:v0.2.0 # Pinning version
+    image: ghcr.io/element-hq/lk-jwt-service:v0.2.2 # Pinning version
     container_name: element-call-jwt
     restart: unless-stopped
     environment:
@@ -91,7 +91,7 @@ services:
       web: # Needs to be reachable by Caddy
 
   livekit:
-    image: livekit/livekit-server:v2.1.3 # Pinning to a specific version is recommended
+    image: livekit/livekit-server:v1.8.4 # Pinning to a specific version is recommended
     container_name: livekit
     # Use config file instead of just environment variables
     command: --config /etc/livekit.yaml

--- a/matrix/docker-compose.yml
+++ b/matrix/docker-compose.yml
@@ -106,10 +106,10 @@ services:
       # Port 7880 is now only needed internally for Caddy proxying to /livekit/sfu
       # - "7880:7880" # Client API and Webhook callback - No longer exposed directly
       - "7881:7881" # TURN/TLS (LiveKit's own TURN, though disabled in config)
-      - "50000-50200:50000-50200/udp" # UDP port range for media over WebRTC
+      - "50100-50200:50100-50200/udp" # UDP port range for media over WebRTC
     volumes:
       # Mount the new config file
-      - ./livekit-config.yaml:/etc/livekit.yaml:ro
+      - /home/fzr/matrix/livekit-config.yaml:/etc/livekit.yaml:ro
     networks:
       default:
       web: # Needs to be reachable by Caddy

--- a/matrix/docker-compose.yml
+++ b/matrix/docker-compose.yml
@@ -71,6 +71,49 @@ services:
       - source: eturnal
         target: /etc/eturnal.yml
 
+  # Added JWT Authentication Service for Element Call
+  lk-jwt-service:
+    image: ghcr.io/element-hq/lk-jwt-service:v0.2.0 # Pinning version
+    container_name: element-call-jwt
+    restart: unless-stopped
+    environment:
+      # Port the JWT service listens on internally
+      - LK_JWT_PORT=8080
+      # Publicly accessible URL for the LiveKit SFU WebSocket endpoint (updated domain)
+      - LIVEKIT_URL=wss://matrixrtc.fariszr.com/livekit/sfu
+      # API Key and Secret (must match LiveKit service and secrets)
+      - LIVEKIT_KEY=(livekit_api_key)
+      - LIVEKIT_SECRET=(livekit_api_secret)
+      # Optional: Restrict call creation to users from specific homeservers
+      - LIVEKIT_LOCAL_HOMESERVERS=fariszr.com # Hardcoded server name
+    networks:
+      default:
+      web: # Needs to be reachable by Caddy
+
+  livekit:
+    image: livekit/livekit-server:v2.1.3 # Pinning to a specific version is recommended
+    container_name: livekit
+    # Use config file instead of just environment variables
+    command: --config /etc/livekit.yaml
+    restart: unless-stopped
+    # LIVEKIT_KEYS is still needed here for the server itself
+    environment:
+      - LIVEKIT_KEYS=(livekit_api_key):(livekit_api_secret)
+      # Remove other env vars now handled by config.yaml
+      # - LIVEKIT_WS_URL=wss://livekit.fariszr.com
+      # - LIVEKIT_PORT=7880
+    ports:
+      # Port 7880 is now only needed internally for Caddy proxying to /livekit/sfu
+      # - "7880:7880" # Client API and Webhook callback - No longer exposed directly
+      - "7881:7881" # TURN/TLS (LiveKit's own TURN, though disabled in config)
+      - "50000-50200:50000-50200/udp" # UDP port range for media over WebRTC
+    volumes:
+      # Mount the new config file
+      - ./livekit-config.yaml:/etc/livekit.yaml:ro
+    networks:
+      default:
+      web: # Needs to be reachable by Caddy
+
 configs:
   synapse-homeserver:
     file: /home/fzr/matrix/homeserver.yaml
@@ -78,6 +121,7 @@ configs:
     file: /home/fzr/matrix/log.config
   eturnal:
     file: /home/fzr/matrix/eturnal.yml
+
 secrets:
   matrix-signing-key:
     file: /home/fzr/matrix/signing.key #added by the create secrets step

--- a/matrix/homeserver.yaml
+++ b/matrix/homeserver.yaml
@@ -1,3 +1,4 @@
+
 # Configuration file for Synapse.
 #
 # This is a YAML file: see [1] for a quick introduction. Note in particular
@@ -67,6 +68,30 @@ url_preview_ip_range_blacklist:
 turn_uris: [ "turns:turn.fariszr.com?transport=udp", "turns:turn.fariszr.com?transport=tcp", "turn:turn.fariszr.com?transport=udp", "turn:turn.fariszr.com?transport=tcp" ]
 turn_shared_secret: "(matrix_turn_shared_secret)"
 turn_user_lifetime: 1h
+
+# Add experimental features required for Element Call (MatrixRTC)
+experimental_features:
+  # MSC3266: Room summary API. Used for knocking over federation.
+  msc3266_enabled: true
+  # MSC4222: Needed for syncv2 state_after. Allows clients to correctly track room state.
+  msc4222_enabled: true
+  # MSC4140: Delayed events are required for proper call participation signalling.
+  # If disabled, you might get stuck calls in Matrix rooms.
+  msc4140_enabled: true
+  # The maximum allowed duration by which sent events can be delayed, as per MSC4140.
+  max_event_delay_duration: 24h
+
+# Adjust rate limiting for call-related events
+rc_message:
+  # Needs to match at least E2EE key sharing frequency plus headroom.
+  # Key sharing events are bursty.
+  per_second: 0.5
+  burst_count: 30
+
+rc_delayed_event_mgmt:
+  # Needs to match at least the heartbeat frequency (5s = 0.2/s) plus headroom.
+  per_second: 1.0 # Increased from example's 1 to be safer
+  burst_count: 20
 
 email:
   # The hostname of the outgoing SMTP server to use. Defaults to 'localhost'.

--- a/matrix/homeserver.yaml
+++ b/matrix/homeserver.yaml
@@ -78,8 +78,9 @@ experimental_features:
   # MSC4140: Delayed events are required for proper call participation signalling.
   # If disabled, you might get stuck calls in Matrix rooms.
   msc4140_enabled: true
-  # The maximum allowed duration by which sent events can be delayed, as per MSC4140.
-  max_event_delay_duration: 24h
+
+# The maximum allowed duration by which sent events can be delayed, as per MSC4140.
+max_event_delay_duration: 24h
 
 # Adjust rate limiting for call-related events
 rc_message:

--- a/matrix/livekit-config.yaml
+++ b/matrix/livekit-config.yaml
@@ -1,0 +1,27 @@
+# Basic LiveKit configuration
+port: 7880 # Port LiveKit listens on internally
+bind_addresses:
+  - "0.0.0.0" # Listen on all interfaces within the container
+
+rtc:
+  tcp_port: 7881
+  port_range_start: 50000 # Match docker-compose port range
+  port_range_end: 50200   # Match docker-compose port range
+  use_external_ip: false # Rely on reverse proxy/NAT
+
+logging:
+  level: info
+
+# Disable LiveKit's internal TURN server since we use eturnal
+turn:
+  enabled: false
+  # domain: matrixrtc.fariszr.com # Not needed if disabled, updated comment for consistency
+  # cert_file: ""
+  # key_file: ""
+  # tls_port: 5349 # Default
+  # udp_port: 443 # Default - Conflicts with Caddy? Better to disable.
+  # external_tls: true # If using external certs, but disabled anyway
+
+# Keys are provided via environment variable LIVEKIT_KEYS in docker-compose.yml
+# keys:
+#   (livekit_api_key): (livekit_api_secret)

--- a/matrix/livekit-config.yaml
+++ b/matrix/livekit-config.yaml
@@ -5,7 +5,7 @@ bind_addresses:
 
 rtc:
   tcp_port: 7881
-  port_range_start: 50000 # Match docker-compose port range
+  port_range_start: 50100 # Match docker-compose port range
   port_range_end: 50200   # Match docker-compose port range
   use_external_ip: false # Rely on reverse proxy/NAT
 


### PR DESCRIPTION
Add matrix-rtc support based on the following guides:
https://github.com/element-hq/element-call/blob/livekit/docs/self-hosting.md

https://willlewis.co.uk/blog/posts/deploy-element-call-backend-with-synapse-and-docker-compose